### PR TITLE
support whitespaces after properties

### DIFF
--- a/lib/csspool/css/parser.y
+++ b/lib/csspool/css/parser.y
@@ -215,6 +215,10 @@ rule
       { @handler.property val.first, val[2], val[3] }
     | property ':' S expr prio
       { @handler.property val.first, val[3], val[4] }
+    | property S ':' expr prio
+      { @handler.property val.first, val[3], val[4] }
+    | property S ':' S expr prio
+      { @handler.property val.first, val[4], val[5] }
     ;
   prio
     : IMPORTANT_SYM { result = true }

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -99,5 +99,13 @@ module CSSPool
       assert_match('none', doc.to_css)
       assert_match('#fff', doc.to_css)
     end
+
+    def test_whitespaces
+      doc = CSSPool.CSS <<-eocss
+        div { border : none; }
+      eocss
+      assert_match('none', doc.to_css)
+      assert_match('border:', doc.to_css)
+    end
   end
 end


### PR DESCRIPTION
according to w3

```
declaration : property S* ':' S* value;
```

Please make new release of gem after merge. Thanks
