### PR TITLE
support ie safe hack

### DIFF
--- a/lib/csspool/css/parser.y
+++ b/lib/csspool/css/parser.y
@@ -226,6 +226,7 @@ rule
     ;
   property
     : IDENT { result = interpret_identifier val[0] }
+    | STAR IDENT { result = interpret_identifier val.join }
     ;
   operator
     : COMMA

--- a/test/css/test_parser.rb
+++ b/test/css/test_parser.rb
@@ -163,6 +163,25 @@ module CSSPool
         assert_equal %w{ background padding }, names
       end
 
+      def test_ie_safe_hack
+        # http://mathiasbynens.be/notes/safe-css-hacks
+        @parser.scan_str <<-eocss
+          .foo {
+            color: black;
+            color: green\\9; /* IE8 and older, but there's more... */
+            *color: blue; /* IE7 and older */
+            _color: red; /* IE6 and older */
+          }
+        eocss
+        declarations = @parser.handler.calls.find_all { |x|
+          x.first == :property
+        }
+        names = declarations.map { |y| y[1].first }
+        assert_equal %w{color color *color _color}, names
+        # values = declarations.map { |y| y[1][1].first.to_s }
+        # assert_equal %w{black green\\9 blue red}, values
+      end
+
       def test_star_attribute
         assert_attribute '*:foo { }'
         assert_attribute 'a *.foo { }'


### PR DESCRIPTION
instead of `green\\9` I get `green\\000009` thats why I commented it out
