### PR TITLE
Support odd but valid semi-colons in rulesets

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -58,6 +58,7 @@ test/sac/test_parser.rb
 test/sac/test_properties.rb
 test/sac/test_terms.rb
 test/test_collection.rb
+test/test_declaration.rb
 test/test_parser.rb
 test/test_selector.rb
 test/visitors/test_children.rb

--- a/lib/csspool/css/parser.y
+++ b/lib/csspool/css/parser.y
@@ -208,10 +208,17 @@ rule
         )
       }
     ;
+  # declarations can be separated by one *or more* semicolons. semi-colons at the start or end of a ruleset are also allowed
+  one_or_more_semis
+    : SEMI
+    | SEMI one_or_more_semis
+    ;
   declarations
-    : declaration SEMI declarations
-    | declaration SEMI
+    : declaration one_or_more_semis declarations
+    | one_or_more_semis declarations
+    | declaration one_or_more_semis
     | declaration
+    | one_or_more_semis
     ;
   declaration
     : property ':' expr prio

--- a/test/test_declaration.rb
+++ b/test/test_declaration.rb
@@ -1,0 +1,39 @@
+require 'helper'
+
+module CSSPool
+  class TestSelector < CSSPool::TestCase
+
+    def test_multiple_semicolons
+      doc = CSSPool.CSS <<-eocss
+        a { background: red;; color: blue; }
+      eocss
+      rs = doc.rule_sets.first
+      assert_equal 2, rs.declarations.size
+    end
+
+    def test_leading_semicolon
+      doc = CSSPool.CSS <<-eocss
+        a { ; background: red; }
+      eocss
+      rs = doc.rule_sets.first
+      assert_equal 1, rs.declarations.size
+    end
+
+    def test_no_trailing_semicolon
+      doc = CSSPool.CSS <<-eocss
+        a { background: red }
+      eocss
+      rs = doc.rule_sets.first
+      assert_equal 1, rs.declarations.size
+    end
+
+    def test_only_semicolon
+      doc = CSSPool.CSS <<-eocss
+        a { ; }
+      eocss
+      rs = doc.rule_sets.first
+      assert_equal 0, rs.declarations.size
+    end
+
+  end
+end


### PR DESCRIPTION
http://www.w3.org/TR/CSS21/grammar.html

A ruleset is:

```
ruleset
  : selector [ ',' S* selector ]*
    '{' S* declaration? [ ';' S* declaration? ]* '}' S*
  ;
```

Therefore these are all valid:

``` css
a { background: red;; color: blue; }
a { ; background: red; }
a { background: red }
a { ; }
```

[Validator results.](http://jigsaw.w3.org/css-validator/validator?text=a+%7B+background%3A+red%3B%3B+color%3A+blue%3B+%7D%0D%0Aa+%7B+%3B+background%3A+red%3B+%7D%0D%0Aa+%7B+background%3A+red+%7D%0D%0Aa+%7B+%3B+%7D&profile=css3&usermedium=all&type=none&warning=1&vextwarning=&lang=en)
