### PR TITLE
Support URL(http://example.com)

### DIFF
--- a/lib/csspool/css/parser.y
+++ b/lib/csspool/css/parser.y
@@ -406,7 +406,7 @@ def interpret_identifier s
 end
 
 def interpret_uri s
-  interpret_escapes s.match(/^url\((.*)\)$/mu)[1].strip.match(/^(['"]?)((?:\\.|.)*)\1$/mu)[2]
+  interpret_escapes s.match(/^url\((.*)\)$/mui)[1].strip.match(/^(['"]?)((?:\\.|.)*)\1$/mu)[2]
 end
 
 def interpret_string_no_quote s

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -87,5 +87,19 @@ module CSSPool
       eocss
       assert_match('foo(1, 2)', doc.to_css)
     end
+
+    def test_url
+      doc = CSSPool.CSS <<-eocss
+        div { background: url(http://example.com); }
+      eocss
+      assert_match 'http://example.com', doc.to_css
+    end
+
+    def test_url_capitalized
+      doc = CSSPool.CSS <<-eocss
+        div { background: URL(http://example.com); }
+      eocss
+      assert_match 'http://example.com', doc.to_css
+    end
   end
 end


### PR DESCRIPTION
http://www.w3.org/TR/CSS21/syndata.html#characters

"All CSS syntax is case-insensitive within the ASCII range (i.e., [a-z] and [A-Z] are equivalent), except for parts that are not under the control of CSS. For example, the case-sensitivity of values of the HTML attributes "id" and "class", of font names, and of URIs lies outside the scope of this specification. Note in particular that element names are case-insensitive in HTML, but case-sensitive in XML."

Meaning, while URLs are case-sensitive, the URL function is not, so saying

``` css
background: URL(http://example.com);
```

is valid. Currently csspool throws this:

```
NoMethodError: undefined method `[]' for nil:NilClass
    parser.y:409:in `interpret_uri'
    parser.y:348:in `_reduce_116'
    parser.y:401:in `_racc_do_parse_c'
    /usr/local/lib/ruby/1.8/racc/parser.rb:99:in `catch'
    /usr/local/lib/ruby/1.8/racc/parser.rb:99:in `_racc_do_parse_c'
    /usr/local/lib/ruby/1.8/racc/parser.rb:99:in `__send__'
    /usr/local/lib/ruby/1.8/racc/parser.rb:99:in `do_parse'
    ./lib/csspool/css/tokenizer.rb:30:in `scan_str'
    ./lib/csspool/sac/parser.rb:11:in `parse'
    ./lib/csspool/css/document.rb:17:in `parse'
    ./lib/csspool.rb:19:in `CSS'
```
