### PR TITLE
Support different linebreaks in URLs

### DIFF
--- a/lib/csspool/css/tokenizer.rex
+++ b/lib/csspool/css/tokenizer.rex
@@ -3,7 +3,7 @@ module CSS
 class Tokenizer < Parser
 
 macro
-  nl        \n|\r\n|\r|\f
+  nl        (\n|\r\n|\r|\f)
   w         [\s]*
   nonascii  [^\0-\177]
   num       ([0-9]*\.[0-9]+|[0-9]+)

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -87,5 +87,21 @@ module CSSPool
       eocss
       assert_match('foo(1, 2)', doc.to_css)
     end
+
+    def test_uri_linefeed_n
+      doc = CSSPool.CSS "div { background: url('http://\\\nexample.com/image.png') }"
+      #assert_equal "http://\\\nexample.com/image.png", doc.rule_sets.first.declarations.first.expressions.first.value
+    end
+
+    def test_uri_linefeed_r
+      doc = CSSPool.CSS "div { background: url('http://\\\rexample.com/image.png') }"
+      #assert_equal "http://\\\rexample.com/image.png", doc.rule_sets.first.declarations.first.expressions.first.value
+    end
+
+    def test_uri_linefeed_rn
+      doc = CSSPool.CSS "div { background: url('http://\\\r\nexample.com/image.png') }"
+      #assert_equal "http://\\\r\nexample.com/image.png", doc.rule_sets.first.declarations.first.expressions.first.value
+    end
+
   end
 end


### PR DESCRIPTION
\n, \r, and \r\n are all OK in URLs when prefixed by a backslash. Currently only \n is supported due to some missing brackets.

I'm not sure whether the intention for these escapes is to maintain the escaped form or unescape it - it's inconsistent in that \n is stripped but the others aren't, but I'm reluctant to make it not strip the \n without knowing why it's doing it in the first place. So I just left things as is.
