### PR TITLE
Really (this time) no reduce/reduce conflicts in grammar

### DIFF
--- a/lib/csspool/css/parser.y
+++ b/lib/csspool/css/parser.y
@@ -485,12 +485,12 @@ rule
           val[2].join(', ')
         )
       }
-    | COLON MOZ_PSEUDO_ELEMENT optional_space any_number_of_idents optional_space RPAREN {
+    | COLON MOZ_PSEUDO_ELEMENT optional_space any_number_of_idents RPAREN {
         result = Selectors::PseudoElement.new(
           interpret_identifier(val[1].sub(/\($/, ''))
         )
       }
-    | COLON COLON MOZ_PSEUDO_ELEMENT optional_space any_number_of_idents optional_space RPAREN {
+    | COLON COLON MOZ_PSEUDO_ELEMENT optional_space any_number_of_idents RPAREN {
         result = Selectors::PseudoElement.new(
           interpret_identifier(val[2].sub(/\($/, ''))
         )
@@ -498,23 +498,18 @@ rule
     ;
   any_number_of_idents
     :
-    | multiple_idents
+    | multiple_idents optional_space
     ;
   multiple_idents
     : IDENT
     | IDENT COMMA multiple_idents
     ;
   # declarations can be separated by one *or more* semicolons. semi-colons at the start or end of a ruleset are also allowed
-  one_or_more_semis
-    : SEMI
-    | one_or_more_semis SEMI
-    ;
   declarations
-    : declaration one_or_more_semis declarations
-    | one_or_more_semis declarations
-    | declaration one_or_more_semis
+    : declarations SEMI
+    | declarations declaration
     | declaration
-    | one_or_more_semis
+    | SEMI
     ;
   declaration
     : declaration_internal { @handler.property val.first }


### PR DESCRIPTION
Last time, when I converted the right recursion in `one_or_more_semis` to left recursion, I accidentally introduced another R/R conflict! Sorry!

In the diff below, you can see an adjustment involving `optional_space`; this one caused a conflict because it can be null, and `any_number_of_idents` can also be null, so if there is a space but no "idents", the parser won't know if the space should be consumed by the first instance of `optional_space` or the second.

Similarly with `one_or_more_semis` -- there were several redundant rules for `declarations`, and if there were semis there, there was more than one way that the rules could be applied to parse them. Now there is only ever one way that the `declarations` rules can be applied.

(I'm just working on the 2.0 release of Racc, and have added much better warnings, which show you just where Racc has difficulty with your grammar. This is how I found these. There are still 3 S/R conflicts, which I may figure out how to fix later.)
